### PR TITLE
Fix html title after repository rename

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ exclude_patterns = []
 
 html_theme = 'furo'
 html_static_path = ['_static']
-html_title = 'Python Docs Transifex Automation'
+html_title = 'Python Docs Transifex Automations'
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
repository slug was renamed to "transifex-automations", so updating html_title to match. This is consistent with the rest of the repository that expected the repository name to be "transifex-automations" already.

<!-- readthedocs-preview python-docs-transifex-automation start -->
----
📚 Documentation preview 📚: https://python-docs-transifex-automation--133.org.readthedocs.build/en/133/

<!-- readthedocs-preview python-docs-transifex-automation end -->