### PR TITLE
Remove `on: push` from TX sample

### DIFF
--- a/sample-workflows/transifex-pull.yml
+++ b/sample-workflows/transifex-pull.yml
@@ -3,9 +3,6 @@ name: Pull Translations from Transifex
 on:
   schedule:
     - cron: '0 0 * * *'
-  push:
-    branches:
-      - '*'
   workflow_dispatch:
 permissions:
   contents: write


### PR DESCRIPTION
The workflow pushes commits and then calls itself yet again, this one should just be on a schedule.