### PR TITLE
Update devguide link in new-traslators.rst

### DIFF
--- a/docs/new-translators.rst
+++ b/docs/new-translators.rst
@@ -24,7 +24,7 @@ Discord ``#translations`` channel), and familiarizing yourself with `PEP 545`_.
 If there is already a repository for your language team, please join and
 introduce yourself.
 
-.. _Translating: https://devguide.python.org/documentation/translating/
+.. _Translating: https://devguide.python.org/documentation/translations/translating/
 .. _Python Developer's Guide: https://devguide.python.org
 .. _PEP 545: https://peps.python.org/pep-0545/
 .. _Docs Community: https://docs-community.readthedocs.io/


### PR DESCRIPTION
I moved the file in the devguide, so to avoid the redirect I update the link here to it's new location.

<!-- readthedocs-preview python-docs-transifex-automation start -->
----
📚 Documentation preview 📚: https://python-docs-transifex-automation--153.org.readthedocs.build/

<!-- readthedocs-preview python-docs-transifex-automation end -->