### PR TITLE
Increase CI freq to every second day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
         description: "Pull translations from Transifex"
         type: boolean
   schedule:
-    - cron: '0 14 * * 5'
+    - cron: '0 14 */2 * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Source strings are updated using a continuous integration workflow under
 `.github/workflows <https://github.com/python-docs-translations/transifex-automation/tree/main/.github/workflows>`_.
 Details:
 
-- Run weekly
+- Run every second day;
 - Run for releases in beta, release candidate, stable, bugfixes and security-fixes status; alpha or EOL are excluded;
 - It **DOES NOT** store translations to be used by the published documentation;
 


### PR DESCRIPTION
I think running every second day to start, and see if we have issues, then we can drop it to daily runs.
For #157