### PR TITLE
Revert "Remove unesecarry msgid removal"

### DIFF
--- a/scripts/remove-msgid.sh
+++ b/scripts/remove-msgid.sh
@@ -52,6 +52,11 @@ remove_msgid  library/codecs.pot '^\\N$'
 remove_msgid  library/re.pot  '^\\N$'
 remove_msgid  reference/lexical_analysis.pot  '^\\N$'
 
+# This string should not be translated, otherwise sphinx-build give warnings
+# Fixed via https://github.com/python/cpython/pull/19470
+remove_msgid  c-api/sys.pot '^Raises an :ref:`auditing event <auditing>` ``sys.addaudithook`` with no arguments.$'
+remove_msgid  library/sys.pot '^Raises an :ref:`auditing event <auditing>` ``sys.addaudithook`` with no arguments.$'
+
 # "object" is too common, and should not be translated in this case.
 # Remove to avoid incorrect translation.
 remove_msgid library/string.templatelib.pot '^object$'


### PR DESCRIPTION
Reverts python-docs-translations/transifex-automations#162

@StanFromIreland Removing this causes 3.10 to fail because https://github.com/python/cpython/pull/19470 was backported to 3.11. I see https://docs.python.org/3.10/ was last rebuilt in July 08, 2025. So I'll keep this for now