### PR TITLE
Limit on.push events to main branch in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 1


### PR DESCRIPTION
Avoids triggering lint.yml on both `push` and `pull_request` events on Pull Requests.