### PR TITLE
Remove obsolete PO files in CI before tx-pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,11 +192,14 @@ jobs:
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
+      # Remove PO files to pull and store exactly what is in Transifex, without leftovers
       - name: Pull translations for all languages
         if: ${{ github.event_name == 'schedule' ||
                (github.event_name == 'workflow_dispatch' && github.event.inputs.pull == 'true') }}
         working-directory: cpython/Doc/locales
         run: |
+          find * -type f -name '*.po'
+          find * -type d -empty -print -delete
           tx pull --all --translations --force
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
                (github.event_name == 'workflow_dispatch' && github.event.inputs.pull == 'true') }}
         working-directory: cpython/Doc/locales
         run: |
-          find ./* -type f -name '*.po'
+          find ./* -type f -name '*.po' -delete
           find ./* -type d -empty -print -delete
           tx pull --all --translations --force
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,8 @@ jobs:
                (github.event_name == 'workflow_dispatch' && github.event.inputs.pull == 'true') }}
         working-directory: cpython/Doc/locales
         run: |
-          find * -type f -name '*.po'
-          find * -type d -empty -print -delete
+          find ./* -type f -name '*.po'
+          find ./* -type d -empty -print -delete
           tx pull --all --translations --force
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}


### PR DESCRIPTION
If the obsolete files are not removed, they might get pushed back to Transifex.