### PR TITLE
`remove-msgid.sh`: Exclude complete grammar msgid

### DIFF
--- a/scripts/remove-msgid.sh
+++ b/scripts/remove-msgid.sh
@@ -61,3 +61,7 @@ remove_msgid  library/sys.pot '^Raises an :ref:`auditing event <auditing>` ``sys
 # "object" is too common, and should not be translated in this case.
 # Remove to avoid incorrect translation.
 remove_msgid library/string.templatelib.pot '^object$'
+
+# This is an include of the complete Python Grammar, it is very long and is
+# modified very frequently.
+remove_msgid reference/grammar.pot '# ========================= START OF THE GRAMMAR ========================='


### PR DESCRIPTION
The string on Transifex: https://app.transifex.com/python-doc/python-newest/viewstrings/#en/reference--grammar/592026532