### PR TITLE
Make pdf artifact return only PDF files

### DIFF
--- a/sample-workflows/test-build.yml
+++ b/sample-workflows/test-build.yml
@@ -57,4 +57,4 @@ jobs:
       - uses: actions/upload-artifact@master
         with:
           name: build-${{ matrix.version }}-pdf
-          path: .
+          path: ./*.pdf


### PR DESCRIPTION
Not filtering the output brings all files generated by from latex builder 