### PR TITLE
Enable epub build

### DIFF
--- a/sample-workflows/test-build.yml
+++ b/sample-workflows/test-build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ '3.14' ]
-        format: [ html, latex ]
+        format: [ html, latex, epub ]
     steps:
       - uses: actions/setup-python@master
         with:


### PR DESCRIPTION
Considering that core dev no longer provides this, teams might want to build themselves.