### PR TITLE
Update CI workflow to use github-push-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,9 @@ jobs:
           git diff-index --cached --quiet HEAD || { git commit -vm "Update translations from Transifex"; }
 
       - name: Push changes
-        working-directory: cpython/Doc/locales
         if: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
-        run: |
-          git push
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
+        with:
+          directory: cpython/Doc/locales
+          branch: ${{ matrix.cpython_version }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 0671d8ab202c4ac093b78433ae5baf74f3fc7246  # frozen: v0.15.15
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 


### PR DESCRIPTION
Fix failing push. The [zizmor changes](https://github.com/python-docs-translations/transifex-automations/pull/237) got us set `persist-credentials: false` on checkout step, which made us fail when trying to push.

https://github.com/python-docs-translations/transifex-automations/actions/runs/26776396669/job/78974733067

```
Run git push
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Process completed with exit code 128.
```