### PR TITLE
ci: update push steps to use GITHUB_TOKEN for authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,5 +242,9 @@ jobs:
       - name: Push changes
         working-directory: cpython/Doc/locales
         if: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push
+          git remote set-url origin \
+            https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git push origin HEAD:${{ matrix.cpython_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,5 +246,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin \
-            https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,4 +247,4 @@ jobs:
         run: |
           git remote set-url origin \
             https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git push origin HEAD:${{ matrix.cpython_version }}
+          git push

--- a/.github/workflows/download-glossary.yml
+++ b/.github/workflows/download-glossary.yml
@@ -62,6 +62,8 @@ jobs:
           name: glossary
 
       - name: Commit and push if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -72,5 +74,7 @@ jobs:
             echo "No changes"
           else
             git commit -m "Auto-update glossary as of $(date +'%Y.%m.%d')"
+            git remote set-url origin \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push
           fi


### PR DESCRIPTION
Alternative to #238. It keeps zizmor satisfied by exposing the GH secret only to steps that need it while not introducing a dependency on a new action.