### PR TITLE
Rename ci workflow to sync-translations for disambiguity

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Sync translations with Transifex
 
 on:
   push:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,4 +3,4 @@ rules:
     ignore:
       - python-docs-theme.yml
       - download-glossary.yml
-      - ci.yml
+      - sync-translations.yml

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 transifex-automations
 =====================
 
-.. |ci| image:: https://github.com/python-docs-translations/transifex-automations/actions/workflows/ci.yml/badge.svg
-   :target: https://github.com/python-docs-translations/transifex-automations/actions/workflows/ci.yml
+.. |ci| image:: https://github.com/python-docs-translations/transifex-automations/actions/workflows/sync-translations.yml/badge.svg
+   :target: https://github.com/python-docs-translations/transifex-automations/actions/workflows/sync-translations.yml
 
 .. |lint| image:: https://github.com/python-docs-translations/transifex-automations/actions/workflows/lint.yml/badge.svg
    :target: https://github.com/python-docs-translations/transifex-automations/actions/workflows/lint.yml

--- a/docs/bumping-release.rst
+++ b/docs/bumping-release.rst
@@ -52,13 +52,13 @@ in one of the version projects to be populated to this project. This drastically
 reduces translation effort replicating one contribution to other strings that are
 exactly the same.
 
-6. Adjust the `CI workflow <https://github.com/python-docs-translations/transifex-automations/tree/main/.github/workflows>`_ with the new Python version:
+6. Adjust the `translation synchronization workflow <https://github.com/python-docs-translations/transifex-automations/tree/main/.github/workflows>`_ with the new Python version:
 
     #. Set ``PYTHON_NEWEST`` environment variable inside ``env`` to the new Python version
     #. Edit ``cpython_version`` inside ``strategy.matrix`` adding the new version to the beginning array
 
-7. Push source strings to python-newest by manually running the CI workflow:
-   Actions_ tab > CI > Run workflow button > "Branch: main" and confirm "Run workflow"
+7. Push source strings to python-newest by manually running the translation synchronization workflow:
+   Actions_ tab > Sync translations with Transifex > Run workflow button > "Branch: main" and confirm "Run workflow"
 
 .. _Actions: https://github.com/python-docs-translations/transifex-automations/actions
 


### PR DESCRIPTION
Current “CI” as workflow name is laconic and ambiguous. I suggest to make it more descriptive.