### PR TITLE
Document machine translation setup and add Transifex links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,9 @@ transifex-automations
 
 |ci| |lint| |docs| |size|
 
-Scripts and procedures for maintaining Python_ documentation translation_ infrastructure under python-doc_ organization in Transifex_.
-For information about translating on transifex for both users and maintainers see the Documentation_.
+Scripts and procedures for maintaining Python documentation translation infrastructure under `python-doc organization in Transifex`_.
 
-.. _Documentation: https://python-docs-transifex-automation.readthedocs.io
-.. _Python: https://www.python.org
-.. _python-doc: https://app.transifex.com/python-doc/
-.. _Transifex: https://www.transifex.com
-.. _translation: https://devguide.python.org/documentation/translating/
+For information about translating on Transifex for both users and maintainers see the documentation_.
+
+.. _python-doc organization in Transifex: https://explore.transifex.com/python-doc/
+.. _documentation: https://python-docs-transifex-automation.readthedocs.io

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ transifex-automations
 
 |ci| |lint| |docs| |size|
 
-Scripts and procedures for maintaining Python documentation translation infrastructure under `python-doc organization in Transifex`_.
+Scripts and procedures for maintaining Python documentation translation infrastructure under the `python-doc organization in Transifex`_.
 
 For information about translating on Transifex for both users and maintainers see the documentation_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Python Docs Transifex Automations documentation
 
 .. tip::
 
-    Python Docs Transifex project is available at https://explore.transifex.com/python-doc/.
+    The Python Docs Transifex project can be found at https://explore.transifex.com/python-doc/.
 
 For translators
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,8 +35,9 @@ Machine translation
 ~~~~~~~~~~~~~~~~~~~
 
 Machine translation in the python-doc_ organization on Transifex uses the DeepL
-integration with a personal API key. Project admins can manage the integration
-in the `machine translation settings <https://app.transifex.com/python-doc/settings/machine-translations/>`_.
+integration with @m_aciek's personal API key (as of 2026-09-10; Discord user
+handle). Project admins can manage the integration in
+the `machine translation settings <https://app.transifex.com/python-doc/settings/machine-translations/>`_.
 
 .. _Python: https://www.python.org
 .. _python-doc: https://app.transifex.com/python-doc/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Python Docs Transifex Automations documentation
 ===============================================
 
+.. tip::
+
+    Python Docs Transifex projects is available at https://explore.transifex.com/python-doc/.
+
 For translators
 ---------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Python Docs Transifex Automations documentation
 
 .. tip::
 
-    Python Docs Transifex projects is available at https://explore.transifex.com/python-doc/.
+    Python Docs Transifex project is available at https://explore.transifex.com/python-doc/.
 
 For translators
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,13 @@ Details:
 
 See also  Translating_ in the Python Developer's Guide for more information.
 
+Machine translation
+~~~~~~~~~~~~~~~~~~~
+
+Machine translation in the python-doc_ organization on Transifex uses the DeepL
+integration with a personal API key. Project admins can manage the integration
+in the `machine translation settings <https://app.transifex.com/python-doc/settings/machine-translations/>`_.
+
 .. _Python: https://www.python.org
 .. _python-doc: https://app.transifex.com/python-doc/
 .. _Transifex: https://www.transifex.com


### PR DESCRIPTION
Add a note about the DeepL integration and its personal API key so we remember how machine translation is configured :)

Link to Transifex from the documentation homepage and README.

Suggested follow-up: change the repository’s website link in GitHub’s right sidebar from https://explore.transifex.com/python-doc/ to https://python-docs-transifex-automation.readthedocs.io.